### PR TITLE
small fix

### DIFF
--- a/backend/GainIt/GainIt.API/DTOs/ViewModels/Projects/UserProjectViewModel.cs
+++ b/backend/GainIt/GainIt.API/DTOs/ViewModels/Projects/UserProjectViewModel.cs
@@ -40,7 +40,7 @@ namespace GainIt.API.DTOs.ViewModels.Projects
                 .ToList();
 
             OwningOrganization = i_Project.OwningOrganization != null
-                ? new FullNonprofitViewModel(i_Project.OwningOrganization)
+                ? new FullNonprofitViewModel(i_Project.OwningOrganization, new List<UserProject>())
                 : null;
 
             ProjectPictureUrl = i_Project.ProjectPictureUrl;


### PR DESCRIPTION
The error occurred because:
The FullNonprofitViewModel constructor was changed to require a List<UserProject> parameter But UserProjectViewModel was still calling the old constructor with just the nonprofit Now it passes both the nonprofit and an empty list of projects